### PR TITLE
Fix JAX allocating too much memory and remove unnecessary import.

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,6 +1,11 @@
+import os
+
+# Set flags before imports
+os.environ['XLA_PYTHON_CLIENT_PREALLOCATE'] = 'false'
+os.environ['WANDB_DIR'] = '/tmp'
+
 import argparse
 import functools
-import os
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import warnings
@@ -14,7 +19,7 @@ import rlax
 import flax.linen as nn
 
 from stable_baselines3.common import type_aliases
-from stable_baselines3.common.callbacks import EvalCallback, CallbackList, BaseCallback
+from stable_baselines3.common.callbacks import CallbackList, BaseCallback
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv, VecMonitor, is_vecenv_wrapped, sync_envs_normalization
 from sbx import SAC
@@ -23,10 +28,6 @@ from sbx.sac.utils import *
 
 import gymnasium as gym
 from shimmy.registration import DM_CONTROL_SUITE_ENVS
-
-
-os.environ['XLA_PYTHON_CLIENT_PREALLOCATE'] = 'false'
-os.environ['WANDB_DIR'] = '/tmp'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-env",         type=str, required=False, default="HumanoidStandup-v4", help="Set Environment.")


### PR DESCRIPTION
Hello,
Setting the flag:
```
os.environ['XLA_PYTHON_CLIENT_PREALLOCATE'] = 'false'
```
did not correctly impact JAX, as it was done after the import. Therefore JAX allocated ~80% of memory of the GPU. When I moved this line of code to the beginning the usage of memory dropped to ~15% (Tested on Nvidia Titan V, HalfCheetah-v4 environment).

Also the import:
```
from stable_baselines3.common.callbacks import EvalCallback,
```

Is not used as EvalCallback is imported from sbx.sac.actor_critic_evaluation_callback. It is safer to delete this unnecessary import as it can clash with the other and also some programs e.g. `isort` when sorting the imports change the order and EvalCallback is then imported from stable_baselines3 instead of sbx.sac.actor_critic_evaluation_callback (that happened in my case when I sorted the imports.)